### PR TITLE
fix: removed .intel? check for nsc, fixes m1 arch issue #3

### DIFF
--- a/Formula/nsc.rb
+++ b/Formula/nsc.rb
@@ -8,7 +8,7 @@ class Nsc < Formula
   version "2.2.2"
   bottle :unneeded
 
-  if OS.mac? && Hardware::CPU.intel?
+  if OS.mac?
     url "https://github.com/nats-io/nsc/releases/download/2.2.2/nsc-darwin-amd64.zip"
     sha256 "e1389d5ec94d71f8b3a59ba651aab6b581cb66a1b48e0884d507fa45b76aaf39"
   end


### PR DESCRIPTION
Simple change to address issue #3 on M1 architectures. Matches the `nats` formula by nixing the architecture check when on Mac.