### PR TITLE
fix: removed .intel? check for nsc, fixes m1 arch issue #3

### DIFF
--- a/Formula/nsc.rb
+++ b/Formula/nsc.rb
@@ -8,7 +8,7 @@ class Nsc < Formula
   version "2.2.3"
   bottle :unneeded
 
-  if OS.mac? && Hardware::CPU.intel?
+  if OS.mac?
     url "https://github.com/nats-io/nsc/releases/download/2.2.3/nsc-darwin-amd64.zip"
     sha256 "d642f75db7d1d3d72d5a7ee5a9f0142c7dce6ac20ce7994af55c2d141b3dd0bc"
   end


### PR DESCRIPTION
Simple change to address issue #3 on M1 architectures. Matches the nats formula by nixing the architecture check when on Mac.