### PR TITLE
Added missing macos intel hardward check in nsc formula

### DIFF
--- a/Formula/nsc.rb
+++ b/Formula/nsc.rb
@@ -16,6 +16,14 @@ class Nsc < Formula
         bin.install "nsc"
       end
     end
+    if Hardware::CPU.intel?
+      url "https://github.com/nats-io/nsc/releases/download/2.7.1/nsc-darwin-amd64.zip"
+      sha256 "606ff0bc98b3249091036fd6ea62c10abae18e03a847336e1e04412881ef1be7"
+
+      def install
+        bin.install "nsc"
+      end
+    end
   end
 
   on_linux do


### PR DESCRIPTION
closes #9 
macos intel hardware check was removed from nsc formula due to which `brew tap` command was not working on intel chip macs.
Fixed the issue.