### PR TITLE
nsc 2.7.1: include amd64 zip files

### DIFF
--- a/Formula/nsc.rb
+++ b/Formula/nsc.rb
@@ -8,6 +8,14 @@ class Nsc < Formula
   version "2.7.1"
 
   on_macos do
+    if Hardware::CPU.intel?
+      url "https://github.com/nats-io/nsc/releases/download/2.7.1/nsc-darwin-amd64.zip"
+      sha256 "d68a0566ce11d70db65f19b288f97b43b69b6c54eccd9ba408181eb561197583"
+
+      def install
+        bin.install "nsc"
+      end
+    end
     if Hardware::CPU.arm?
       url "https://github.com/nats-io/nsc/releases/download/2.7.1/nsc-darwin-arm64.zip"
       sha256 "18406726719c787d13c5ae241c3cbdf4d5a7a348d68f07aab7f359f2c713a8b3"
@@ -22,6 +30,14 @@ class Nsc < Formula
     if Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
       url "https://github.com/nats-io/nsc/releases/download/2.7.1/nsc-linux-arm.zip"
       sha256 "b56d3ad2997ad6ed02ab1fc26dbff840ffcaedb4b071cd811a336cf2d1226a8b"
+
+      def install
+        bin.install "nsc"
+      end
+    end
+    if Hardware::CPU.intel?
+      url "https://github.com/nats-io/nsc/releases/download/2.7.1/nsc-linux-amd64.zip"
+      sha256 "ebea437bff9d92ac0e7bbccadafde62eb4f967ee05ce9f12c531c3c7f3b19362"
 
       def install
         bin.install "nsc"


### PR DESCRIPTION
After upgrading goreleaser-pro to v1.8.3-pro and so fixing the brew architectures generation bug, I checked out the nsc code to tag `2.7.1` and then ran: `goreleaser release --skip-announce --skip-publish -p 3 --rm-dist`

The resulting `SHA256SUMS-nsc.txt` files are identical.

This is the updated Homebrew `nsc.rb` copied into place as-is.
