### PR TITLE
Refactor nats formula

### DIFF
--- a/Formula/nats.rb
+++ b/Formula/nats.rb
@@ -7,49 +7,34 @@ class Nats < Formula
   version "0.1.5"
 
   on_macos do
-    if Hardware::CPU.arm?
+    on_arm do
       url "https://github.com/nats-io/natscli/releases/download/v0.1.5/nats-0.1.5-darwin-arm64.zip"
       sha256 "67be29694ae393e277b102cff168052b1874608287c038dcc72b35068699c4a8"
-
-      def install
-        bin.install "nats"
-      end
     end
-    if Hardware::CPU.intel?
+    on_intel do
       url "https://github.com/nats-io/natscli/releases/download/v0.1.5/nats-0.1.5-darwin-amd64.zip"
       sha256 "de85e408132209991e221bc1f4f67b360dac9ec201e5d26704af9a12632d2b28"
-
-      def install
-        bin.install "nats"
-      end
     end
   end
 
   on_linux do
-    if Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-      url "https://github.com/nats-io/natscli/releases/download/v0.1.5/nats-0.1.5-linux-arm6.zip"
-      sha256 "7d56537f53d0b769328094afb927480ad9576251a809af2ab9b657836938b3fd"
-
-      def install
-        bin.install "nats"
+    on_arm do
+      if Hardware::CPU.is_64_bit?
+        url "https://github.com/nats-io/natscli/releases/download/v0.1.5/nats-0.1.5-linux-arm64.zip"
+        sha256 "49d3157511e4f8d61bdee273b4ea5d19821c454b261fe18568e18254febb344f"
+      else
+        url "https://github.com/nats-io/natscli/releases/download/v0.1.5/nats-0.1.5-linux-arm6.zip"
+        sha256 "7d56537f53d0b769328094afb927480ad9576251a809af2ab9b657836938b3fd"
       end
     end
-    if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/nats-io/natscli/releases/download/v0.1.5/nats-0.1.5-linux-arm64.zip"
-      sha256 "49d3157511e4f8d61bdee273b4ea5d19821c454b261fe18568e18254febb344f"
-
-      def install
-        bin.install "nats"
-      end
-    end
-    if Hardware::CPU.intel?
+    on_intel do
       url "https://github.com/nats-io/natscli/releases/download/v0.1.5/nats-0.1.5-linux-amd64.zip"
       sha256 "728c562e8f59bacd5eb016a6db2664e343b79f3c6642ba03fb9fb1dce7a2bc40"
-
-      def install
-        bin.install "nats"
-      end
     end
+  end
+
+  def install
+    bin.install "nats"
   end
 
   test do


### PR DESCRIPTION
This change refactors the nats homebrew recipe.

The primary change is to use a common install block.

There are also minor changes to the way the url and sha256 hashes are determined, using `on_arm` and `on_intel` instead of `Hardware::CPU.xxx?`.

This is a precursor to another incoming PR to add the ability to build from HEAD.
