### PR TITLE
Add support for building from HEAD

### DIFF
--- a/Formula/nats.rb
+++ b/Formula/nats.rb
@@ -7,49 +7,34 @@ class Nats < Formula
   version "0.1.5"
 
   on_macos do
-    if Hardware::CPU.arm?
+    on_arm do
       url "https://github.com/nats-io/natscli/releases/download/v0.1.5/nats-0.1.5-darwin-arm64.zip"
       sha256 "67be29694ae393e277b102cff168052b1874608287c038dcc72b35068699c4a8"
-
-      def install
-        bin.install "nats"
-      end
     end
-    if Hardware::CPU.intel?
+    on_intel do
       url "https://github.com/nats-io/natscli/releases/download/v0.1.5/nats-0.1.5-darwin-amd64.zip"
       sha256 "de85e408132209991e221bc1f4f67b360dac9ec201e5d26704af9a12632d2b28"
-
-      def install
-        bin.install "nats"
-      end
     end
   end
 
   on_linux do
-    if Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-      url "https://github.com/nats-io/natscli/releases/download/v0.1.5/nats-0.1.5-linux-arm6.zip"
-      sha256 "7d56537f53d0b769328094afb927480ad9576251a809af2ab9b657836938b3fd"
-
-      def install
-        bin.install "nats"
+    on_arm do
+      if Hardware::CPU.is_64_bit?
+        url "https://github.com/nats-io/natscli/releases/download/v0.1.5/nats-0.1.5-linux-arm64.zip"
+        sha256 "49d3157511e4f8d61bdee273b4ea5d19821c454b261fe18568e18254febb344f"
+      else
+        url "https://github.com/nats-io/natscli/releases/download/v0.1.5/nats-0.1.5-linux-arm6.zip"
+        sha256 "7d56537f53d0b769328094afb927480ad9576251a809af2ab9b657836938b3fd"
       end
     end
-    if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/nats-io/natscli/releases/download/v0.1.5/nats-0.1.5-linux-arm64.zip"
-      sha256 "49d3157511e4f8d61bdee273b4ea5d19821c454b261fe18568e18254febb344f"
-
-      def install
-        bin.install "nats"
-      end
-    end
-    if Hardware::CPU.intel?
+    on_intel do
       url "https://github.com/nats-io/natscli/releases/download/v0.1.5/nats-0.1.5-linux-amd64.zip"
       sha256 "728c562e8f59bacd5eb016a6db2664e343b79f3c6642ba03fb9fb1dce7a2bc40"
-
-      def install
-        bin.install "nats"
-      end
     end
+  end
+
+  def install
+    bin.install "nats"
   end
 
   test do

--- a/Formula/nats.rb
+++ b/Formula/nats.rb
@@ -6,6 +6,11 @@ class Nats < Formula
   homepage "https://github.com/nats-io/nats"
   version "0.1.5"
 
+  head do
+    url "https://github.com/nats-io/natscli.git", branch: "main"
+    depends_on "go" => :build
+  end
+
   on_macos do
     on_arm do
       url "https://github.com/nats-io/natscli/releases/download/v0.1.5/nats-0.1.5-darwin-arm64.zip"
@@ -34,7 +39,14 @@ class Nats < Formula
   end
 
   def install
-    bin.install "nats"
+    if build.head?
+      cd "nats" do
+        system "go", "build"
+        bin.install "nats"
+      end
+    else
+      bin.install "nats"
+    end
   end
 
   test do


### PR DESCRIPTION
Add support for building from HEAD.

Here's a demo:
```
❯ command -v nats

❯ brew install nats --HEAD
==> Fetching nats-io/nats-tools/nats
==> Cloning https://github.com/nats-io/natscli.git
Updating /Users/robin/Library/Caches/Homebrew/nats--git
==> Checking out branch main
Already on 'main'
Your branch is up to date with 'origin/main'.
HEAD is now at 8f8cff9 Merge pull request #1170 from ploubser/issue_577
==> Installing nats from nats-io/nats-tools
==> go build
🍺  /opt/homebrew/Cellar/nats/HEAD-8f8cff9: 6 files, 38.4MB, built in 3 seconds
==> Running `brew cleanup nats`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).

❯ command -v nats
/opt/homebrew/bin/nats

❯ nats --version
(devel)
```

Would be nice if `go build` put a better version in the binary.
